### PR TITLE
fixed problem in read write inconsistent keyword for boolean mask

### DIFF
--- a/nddata/nddata/mixins/ndio.py
+++ b/nddata/nddata/mixins/ndio.py
@@ -165,7 +165,7 @@ def write_nddata_fits(ndd, filename, ext_mask='mask', ext_uncert='uncert',
     number ``0``).
     """
     # Comment card strings to allow roundtripping (must be identical to read!)
-    kw_hdr_masktype = 'boolmask'
+    kw_hdr_masktype = 'boolean mask'
     kw_hdr_uncerttype = {
         StdDevUncertainty: 'standard deviation uncertainty',
         UnknownUncertainty: 'unknown uncertainty type'}


### PR DESCRIPTION
and added a test to cover the case if the unit is unparsable during read
and that the header keyword is deleted if no unit is set during write