### PR TITLE
Read HDULists like fits files

### DIFF
--- a/nddata/nddata/mixins/ndio.py
+++ b/nddata/nddata/mixins/ndio.py
@@ -105,9 +105,19 @@ def read_nddata_fits(filename, ext_data=0, ext_meta=0, ext_mask='mask',
     -------
     ndd : `~nddata.nddata.NDDataBase`
         The wrapped FITS file contents.
-    """
 
-    with fits.open(filename, mode='readonly', **kwargs_for_open) as hdus:
+    Notes
+    -----
+    It should also be able to process if the ``filename`` is an already loaded
+    `~astropy.io.fits.HDUList`.
+    """
+    # It should also support if a HDUList is passed in here. The HDUList also
+    # supports the context manager protocol so we open the file if it's not
+    # a HDUList but if it's a HDUList we just use the HDUList as context
+    # manager.
+    isfile = not isinstance(filename, fits.HDUList)
+    with (fits.open(filename, mode='readonly', **kwargs_for_open) if isfile
+            else filename) as hdus:
         # Read the data and meta from the specified extensions
         data = hdus[ext_data].data
         if dtype is not None:

--- a/nddata/nddata/mixins/tests/test_ndio.py
+++ b/nddata/nddata/mixins/tests/test_ndio.py
@@ -3,6 +3,8 @@ from __future__ import (absolute_import, division, print_function,
 
 from string import ascii_lowercase
 
+from astropy.io import fits
+
 from ...nddata import NDDataBase
 from ...nduncertainty_stddev import StdDevUncertainty
 from ...nduncertainty_unknown import UnknownUncertainty
@@ -357,3 +359,14 @@ class TestIOFunctions(object):
         assert isinstance(ndd3, NDDataIO)
 
     # TODO: Add one test for NDDataRef and NDDataArray!
+
+
+def test_hdulist():
+    # It should also work if the "filename" is already a HDUList.
+    data = randdata()
+    mask = randdata()
+    hdus = fits.HDUList([fits.PrimaryHDU(data),
+                         fits.ImageHDU(mask, name='mask')])
+    ndd = NDDataIO.read(hdus, format='simple_fits')
+    np.testing.assert_array_equal(ndd.data, data)
+    np.testing.assert_array_equal(ndd.mask, mask)


### PR DESCRIPTION
HDULists can now be read with NDData.read(HDUList, format="simple_fits")

also renamed test file

fixes #65